### PR TITLE
[autoscaler] Add Ray prometheus metrics to CloudWatch.

### DIFF
--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
@@ -8,6 +8,74 @@
       "port":31000
    },
    "logs":{
+      "metrics_collected": {
+        "prometheus": {
+          "log_group_name": "{cluster_name}-Prometheus",
+          "prometheus_config_path": "/opt/prometheus-2.25.0.linux-amd64/prometheus.yml",
+          "emf_processor": {
+            "metric_declaration_dedup": true,
+            "metric_namespace": "{cluster_name}-Prometheus",
+            "metric_unit":{
+              "python_gc_collections_total": "Count",
+              "python_gc_objects": "Count",
+              "python_gc_objects_uncollectable_total": "Count",
+              "python_gc_objects_collected_total": "Count",
+              "ray_cluster_active_nodes": "Count",
+              "ray_cluster_pending_nodes": "Count",
+              "ray_node_cpu_count": "Count",
+              "ray_node_cpu_utilization": "Percent",
+              "ray_node_disk_free": "Bytes",
+              "ray_node_disk_usage": "Bytes",
+              "ray_node_disk_utilization_percentage": "Percent",
+              "ray_node_mem_available": "Bytes",
+              "ray_node_mem_total": "Bytes",
+              "ray_node_mem_used": "Bytes",
+              "ray_node_network_receive_speed": "Bytes",
+              "ray_node_network_received": "Bytes",
+              "ray_node_network_send_speed": "Bytes",
+              "ray_node_network_sent": "Bytes",
+              "ray_avg_num_executed_tasks": "Count",
+              "ray_avg_num_scheduled_tasks": "Count",
+              "ray_avg_num_spilled_back_tasks": "Count",
+              "ray_object_manager_num_pull_requests": "Count",
+              "ray_object_store_available_memory": "Bytes",
+              "ray_object_store_used_memory": "Bytes",
+              "ray_object_store_num_local_objects": "Count",
+              "ray_object_directory_subscriptions": "Count",
+              "ray_object_directory_added_locations": "Count",
+              "ray_object_directory_removed_locations": "Count",
+              "ray_object_directory_lookups": "Count",
+              "ray_object_directory_updates": "Count",
+              "ray_pending_actors": "Count",
+              "ray_pending_placement_groups": "Count",
+              "ray_raylet_cpu": "Count",
+              "ray_raylet_mem": "Bytes",
+              "process_max_fds": "Count",
+              "process_open_fds": "Count",
+              "process_resident_memory_bytes": "Bytes",
+              "process_virtual_memory_bytes": "Bytes",
+              "process_start_time_seconds": "Seconds",
+              "process_cpu_seconds_total": "Seconds"
+            },
+            "metric_declaration": [
+              {
+                "source_labels": [
+                  "job"
+                ],
+                "label_matcher": "ray",
+                "dimensions": [
+                  [
+                    "instance"
+                  ]
+                ],
+                "metric_selectors": [
+                  ""
+                ]
+              }
+            ]
+          }
+        }
+      },
       "logs_collected":{
          "files":{
             "collect_list":[

--- a/python/ray/autoscaler/aws/cloudwatch/prometheus.yml
+++ b/python/ray/autoscaler/aws/cloudwatch/prometheus.yml
@@ -1,0 +1,16 @@
+# Prometheus config file
+
+# my global config
+global:
+  scrape_interval:     10s
+  evaluation_interval: 10s
+  scrape_timeout: 10s
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+- job_name: 'ray'
+  file_sd_configs:
+  - files:
+    - '/tmp/ray/prom_metrics_service_discovery.json'
+    refresh_interval: 1m

--- a/python/ray/autoscaler/aws/cloudwatch/prometheus_ray_up.sh
+++ b/python/ray/autoscaler/aws/cloudwatch/prometheus_ray_up.sh
@@ -1,0 +1,42 @@
+###########################################################################################################
+#This bash script is meant to support prometheus metrics collection via cloudwatch agent.
+#You can view the ray metrics being collected through AWS CloudWatch console.
+###########################################################################################################
+
+USAGE_INSTRUCTIONS='Usage: prometheus_ray_up.sh [OPTIONS] CLUSTER_CONFIG_FILE'
+
+# ray up to start a new cluster
+ray up "$@"
+
+if [ $? -eq 0 ]; then
+  AUTOSCALER_CONFIG_FILE=$(sed 's/.* //' <<< "$@")
+  if [ ! -f "$AUTOSCALER_CONFIG_FILE" ]; then
+    echo "Cluster config file not found"
+    echo "$USAGE_INSTRUCTIONS"
+    exit 1
+  else
+    CLUSTER_NAME=$(grep 'cluster_name' $AUTOSCALER_CONFIG_FILE| cut -d ':' -f 2 | xargs)
+  fi
+
+  # TODO remove the version number hardcoding from this script
+  # download the latest prometheus
+  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo wget https://github.com/prometheus/prometheus/releases/download/v2.25.0/prometheus-2.25.0.linux-amd64.tar.gz -P /opt"
+  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt && sudo tar xvfz prometheus-2.25.0.linux-amd64.tar.gz"
+  echo "Successfully installed prometheus on head node"
+
+  # replace the default prometheus server configuration with ray services discovery supported configuration
+  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo cp --remove-destination /tmp/prometheus.yml /opt/prometheus-2.25.0.linux-amd64"
+  echo "Successfully configured prometheus on head node"
+
+  # start the prometheus server
+  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt/prometheus-2.25.0.linux-amd64 && sudo ./prometheus --config.file=prometheus.yml --web.enable-lifecycle --log.level=info &"
+  echo "Successfully started prometheus on head node"
+
+  # restart the cloudwatch agent with prometheus integrated
+  echo "Restarting cloudwatch agent...this may take a few minutes."
+  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop"
+  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c ssm:ray_cloudwatch_agent_config_$CLUSTER_NAME"
+
+else
+  echo "Failed while waiting for ray up command to complete."
+fi

--- a/python/ray/autoscaler/aws/example-cloudwatch.yaml
+++ b/python/ray/autoscaler/aws/example-cloudwatch.yaml
@@ -34,3 +34,7 @@ worker_nodes:
     InstanceType: r5n.2xlarge
     ImageId: latest_dlami # Deep Learning AMI (Ubuntu 18.04) Version 27.0
     SecurityGroupIds:
+
+file_mounts: {
+    "/tmp" : "cloudwatch/prometheus.yml"
+}


### PR DESCRIPTION
## Why are these changes needed?
These changes add a set of improvements to enable automatic collection of Ray pre-selected system-level metrics exposed in Prometheus format. Durable Prometheus metrics collected can be viewed directly on CloudWatch console.

## Related issue number

https://github.com/ray-project/ray/issues/8967

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
