### PR TITLE
[autoscaler] Add CDK project for CloudFormation setup

### DIFF
--- a/python/ray/autoscaler/_private/aws/cdk/README.md
+++ b/python/ray/autoscaler/_private/aws/cdk/README.md
@@ -1,0 +1,66 @@
+
+# CDK Integration with SunGate
+
+This is a CDK Python project to automate the process of configuring AWS resources 
+needed for setting up a Ray cluster. It defines cloud infrastructure required to 
+launch the cluster as code, and delegates to AWS CloudFormation for 
+infrastructure provisioning.
+
+To install the AWS CDK Toolkit, follow the [official developer guide](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_prerequisites).
+
+First, you will need to install the AWS CDK:
+
+```
+$ sudo npm install -g aws-cdk
+```
+
+You can check the toolkit version with this command:
+
+```
+$ cdk --version
+```
+
+Now you are ready to create a virtualenv:
+
+```
+$ python3 -m venv .venv
+```
+
+Activate your virtualenv:
+
+```
+$ source .venv/bin/activate
+```
+Install the required dependencies:
+
+```
+$ pip install -r requirements.txt
+```
+
+At this point, you can deploy the stack by executing:
+```
+./cdk-deploy.sh -s demo # stack prefix
+```
+This shell script calls `cdk deploy` under the hood and displays progress 
+information as your stack is deployed. When it's done, the command prompt 
+reappears. You can go to the CloudFormation console and see that it lists 
+`demo-amzn-ray-cdk`.
+
+## Project contents
+
+`README.md` -- The introductory README for this project.
+
+`ray_ec2_stack.py` —- A custom CDK stack construct that is the core of the 
+AmznRay CDK application. It is where we bring the core stack components together 
+before synthesizing our Cloudformation template.
+
+`requirements.txt` —- Pip uses this file to install all of the dependencies for 
+this CDK app.
+
+## Useful commands
+
+ * `cdk ls`          list all stacks in the app
+ * `cdk synth`       emits the synthesized CloudFormation template
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk docs`        open CDK documentation

--- a/python/ray/autoscaler/_private/aws/cdk/README.md
+++ b/python/ray/autoscaler/_private/aws/cdk/README.md
@@ -1,5 +1,5 @@
 
-# CDK Integration with SunGate
+# CDK Integration with Ray
 
 This is a CDK Python project to automate the process of configuring AWS resources 
 needed for setting up a Ray cluster. It defines cloud infrastructure required to 

--- a/python/ray/autoscaler/_private/aws/cdk/app.py
+++ b/python/ray/autoscaler/_private/aws/cdk/app.py
@@ -1,72 +1,66 @@
 #!/usr/bin/env python3
 
 import os
-import boto3
 import sys
+import boto3
+
 from aws_cdk import core
 from ray_ec2.ray_ec2_stack import CdkStack, AmazonRayStackProps
 
 # amzn-ray 1.2.0, cp37, us-east-1
 DEFAULT_AMZN_RAY_AMI = "ami-0a4da390e7a168bb9"
+AMZN_RAY_AMI_ACCOUNT = "160082703681"
 
 
 def _get_default_ami_helper():
-    client = boto3.client('ec2')
+    client = boto3.client("ec2")
 
     if "PYENV_VERSION" not in os.environ.keys():
-        pyenv_version = "{}{}".format(sys.version_info.major, sys.version_info.minor)
+        pyenv_version = "{}{}".format(sys.version_info.major,
+                                      sys.version_info.minor)
     else:
         pyenv_version = "".join(os.environ["PYENV_VERSION"].split("."))
     version_filter = "cp" + pyenv_version
-    filters = [
-        {
-            "Name": "owner-id",
-            "Values": [
-                "160082703681",
-            ]
-        },
-        {
-            "Name": "name",
-            "Values": [
-                "*" + version_filter + "*"
-            ]
-        },
-        {
-            "Name": "state",
-            "Values": [
-                "available",
-            ]
-        },
-        {
-            "Name": "is-public",
-            "Values": [
-                "true",
-            ]
-        }
-    ]
-    describe_image_response = client.describe_images(
-        Filters=filters
-    )
+    filters = [{
+        "Name": "owner-id",
+        "Values": [
+            AMZN_RAY_AMI_ACCOUNT,
+        ]
+    }, {
+        "Name": "name",
+        "Values": ["*" + version_filter + "*"]
+    }, {
+        "Name": "state",
+        "Values": [
+            "available",
+        ]
+    }, {
+        "Name": "is-public",
+        "Values": [
+            "true",
+        ]
+    }]
+    describe_image_response = client.describe_images(Filters=filters)
     image_list = describe_image_response.get("Images", [])
     ami_match = False
     if image_list:
-        sorted_image_response = sorted(
-            image_list, key=lambda k: k["CreationDate"], reverse=True)
+        sorted_image_response = sorted(image_list,
+                                       key=lambda k: k["CreationDate"],
+                                       reverse=True)
         ami_res = sorted_image_response[0].get("ImageId", "")
         if ami_res:
             ami_match = True
     if not ami_match:
-            ami_res = DEFAULT_AMZN_RAY_AMI
-            print("Default AMI: \"Linux - Python 3.7 - Amazon Ray 1.2.0\" "
-                  "in us-east-1.")
+        ami_res = DEFAULT_AMZN_RAY_AMI
+        print("Default AMI: \"Linux - Python 3.7 - Amazon Ray 1.2.0\" "
+              "in us-east-1.")
     print(f"Default AMI ID: {ami_res}")
     return ami_res
 
+
 # Define your account id to make import vpc work
-env_cn = core.Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
-)
+env_cn = core.Environment(account=os.environ["CDK_DEFAULT_ACCOUNT"],
+                          region=os.environ["CDK_DEFAULT_REGION"])
 app = core.App()
 
 if "AMI" not in os.environ.keys():
@@ -78,16 +72,9 @@ if "CDK_PREFIX" not in os.environ.keys():
     raise KeyError("CDK prefix not defined in the environment. "
                    "Add it via \'export CDK_PREFIX=your_prefix\'")
 
-amazon_ray_props = AmazonRayStackProps(
-    prefix=os.environ["CDK_PREFIX"],
-    ami=ami
-)
+amazon_ray_props = AmazonRayStackProps(prefix=os.environ["CDK_PREFIX"],
+                                       ami=ami)
 
-sungate_stack = CdkStack(
-    app,
-    id="cdk-ray",
-    env=env_cn,
-    props=amazon_ray_props
-)
+sungate_stack = CdkStack(app, id="cdk-ray", env=env_cn, props=amazon_ray_props)
 
 app.synth()

--- a/python/ray/autoscaler/_private/aws/cdk/app.py
+++ b/python/ray/autoscaler/_private/aws/cdk/app.py
@@ -75,6 +75,6 @@ if "CDK_PREFIX" not in os.environ.keys():
 amazon_ray_props = AmazonRayStackProps(prefix=os.environ["CDK_PREFIX"],
                                        ami=ami)
 
-sungate_stack = CdkStack(app, id="cdk-ray", env=env_cn, props=amazon_ray_props)
+ray_stack = CdkStack(app, id="cdk-ray", env=env_cn, props=amazon_ray_props)
 
 app.synth()

--- a/python/ray/autoscaler/_private/aws/cdk/app.py
+++ b/python/ray/autoscaler/_private/aws/cdk/app.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import os
+import boto3
+import sys
+from aws_cdk import core
+from ray_ec2.ray_ec2_stack import CdkStack, AmazonRayStackProps
+
+# amzn-ray 1.2.0, cp37, us-east-1
+DEFAULT_AMZN_RAY_AMI = "ami-0a4da390e7a168bb9"
+
+
+def _get_default_ami_helper():
+    client = boto3.client('ec2')
+
+    if "PYENV_VERSION" not in os.environ.keys():
+        pyenv_version = "{}{}".format(sys.version_info.major, sys.version_info.minor)
+    else:
+        pyenv_version = "".join(os.environ["PYENV_VERSION"].split("."))
+    version_filter = "cp" + pyenv_version
+    filters = [
+        {
+            "Name": "owner-id",
+            "Values": [
+                "160082703681",
+            ]
+        },
+        {
+            "Name": "name",
+            "Values": [
+                "*" + version_filter + "*"
+            ]
+        },
+        {
+            "Name": "state",
+            "Values": [
+                "available",
+            ]
+        },
+        {
+            "Name": "is-public",
+            "Values": [
+                "true",
+            ]
+        }
+    ]
+    describe_image_response = client.describe_images(
+        Filters=filters
+    )
+    image_list = describe_image_response.get("Images", [])
+    ami_match = False
+    if image_list:
+        sorted_image_response = sorted(
+            image_list, key=lambda k: k["CreationDate"], reverse=True)
+        ami_res = sorted_image_response[0].get("ImageId", "")
+        if ami_res:
+            ami_match = True
+    if not ami_match:
+            ami_res = DEFAULT_AMZN_RAY_AMI
+            print("Default AMI: \"Linux - Python 3.7 - Amazon Ray 1.2.0\" "
+                  "in us-east-1.")
+    print(f"Default AMI ID: {ami_res}")
+    return ami_res
+
+# Define your account id to make import vpc work
+env_cn = core.Environment(
+    account=os.environ["CDK_DEFAULT_ACCOUNT"],
+    region=os.environ["CDK_DEFAULT_REGION"]
+)
+app = core.App()
+
+if "AMI" not in os.environ.keys():
+    ami = _get_default_ami_helper()
+else:
+    ami = os.environ["AMI"]
+
+if "CDK_PREFIX" not in os.environ.keys():
+    raise KeyError("CDK prefix not defined in the environment. "
+                   "Add it via \'export CDK_PREFIX=your_prefix\'")
+
+amazon_ray_props = AmazonRayStackProps(
+    prefix=os.environ["CDK_PREFIX"],
+    ami=ami
+)
+
+sungate_stack = CdkStack(
+    app,
+    id="cdk-ray",
+    env=env_cn,
+    props=amazon_ray_props
+)
+
+app.synth()

--- a/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
+++ b/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
@@ -48,7 +48,7 @@ if [ "$pyenvversion" ]; then
         echo "error: pyenv ${pyenvversion} not supported. Chose from: ${SUPPORTED_PYENV_VERSIONS[*]}"
         exit 1
     else
-        export PYENV_VERSION_SUNGATE=$pyenvversion
+        export PYENV_VERSION_RAY=$pyenvversion
     fi
 else
     echo "Using default pyenv version"

--- a/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
+++ b/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+progname=`basename $0`
+declare -a SUPPORTED_PYENV_VERSIONS=("3.6","3.7","3.8")
+
+usage() {
+    echo "usage: cdk-deploy -s stack-prefix [-a ami-id] [-p pyenv-version]"
+}
+
+while [[ $# -gt 0 ]]
+do
+    opt="$1"
+    shift
+    current_arg="$1"
+    if [[ "$current_arg" =~ ^-{1,2}.* ]]; then
+        usage >&2
+    fi
+    case "$opt" in
+        -s|--stack-prefix) prefix="$1"; shift ;;
+        -a|--ami-id) amiid="$1"; shift ;;
+        -p|--pyenv-version) pyenvversion="$1"; shift ;;
+        *            ) echo "ERROR: Invalid option: \""$opt"\"" >&2
+                       exit 1 ;;
+    esac
+done
+
+if [ -z "$prefix" ]; then
+    usage >&2
+    echo "Please specify a prefix to setup AWS resources (e.g.: demo). " >&2
+    exit 1
+else
+    echo "stack-prefix identified: $prefix"
+    export CDK_PREFIX=$prefix
+fi
+
+if [ $amiid ]; then
+    echo "Using user defined EC2 AMI: ${amiid}"
+    export AMI=$amiid
+else
+    echo "Using default AMI."
+fi
+echo "For more regional AMIs, check https://github.com/amzn/amazon-ray#images"
+
+if [ $pyenvversion ]; then
+    if [[ ! "${SUPPORTED_PYENV_VERSIONS[@]}" =~ "${pyenvversion}" ]]; then
+        echo "Supported pyenv version: ${SUPPORTED_PYENV_VERSIONS[@]}"
+        exit 1
+    else
+        export PYENV_VERSION_SUNGATE=$pyenvversion
+    fi
+else
+    echo "Using default pyenv version"
+fi
+
+cdk deploy
+exit $?

--- a/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
+++ b/python/ray/autoscaler/_private/aws/cdk/cdk-deploy.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-progname=`basename $0`
-declare -a SUPPORTED_PYENV_VERSIONS=("3.6","3.7","3.8")
+
+# Cause the script to exit if a single command fails.
+set -e
+
+declare -a SUPPORTED_PYENV_VERSIONS=("3.6" "3.7" "3.8")
 
 usage() {
     echo "usage: cdk-deploy -s stack-prefix [-a ami-id] [-p pyenv-version]"
@@ -18,7 +21,7 @@ do
         -s|--stack-prefix) prefix="$1"; shift ;;
         -a|--ami-id) amiid="$1"; shift ;;
         -p|--pyenv-version) pyenvversion="$1"; shift ;;
-        *            ) echo "ERROR: Invalid option: \""$opt"\"" >&2
+        *            ) echo "ERROR: Invalid option: \" $opt \"" >&2
                        exit 1 ;;
     esac
 done
@@ -32,7 +35,7 @@ else
     export CDK_PREFIX=$prefix
 fi
 
-if [ $amiid ]; then
+if [ "$amiid" ]; then
     echo "Using user defined EC2 AMI: ${amiid}"
     export AMI=$amiid
 else
@@ -40,9 +43,9 @@ else
 fi
 echo "For more regional AMIs, check https://github.com/amzn/amazon-ray#images"
 
-if [ $pyenvversion ]; then
-    if [[ ! "${SUPPORTED_PYENV_VERSIONS[@]}" =~ "${pyenvversion}" ]]; then
-        echo "Supported pyenv version: ${SUPPORTED_PYENV_VERSIONS[@]}"
+if [ "$pyenvversion" ]; then
+    if [[ ! "${SUPPORTED_PYENV_VERSIONS[*]}" =~ ${pyenvversion[*]} ]]; then
+        echo "error: pyenv ${pyenvversion} not supported. Chose from: ${SUPPORTED_PYENV_VERSIONS[*]}"
         exit 1
     else
         export PYENV_VERSION_SUNGATE=$pyenvversion

--- a/python/ray/autoscaler/_private/aws/cdk/cdk.json
+++ b/python/ray/autoscaler/_private/aws/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ray/autoscaler/_private/aws/cdk/ray_ec2/ray_ec2_stack.py
+++ b/python/ray/autoscaler/_private/aws/cdk/ray_ec2/ray_ec2_stack.py
@@ -1,16 +1,10 @@
-from aws_cdk import (
-    aws_ec2 as ec2,
-    aws_iam as iam,
-    core    
-)
+from aws_cdk import (aws_ec2 as ec2, aws_iam as iam, core)
+from aws_cdk.aws_ec2 import CfnLaunchTemplate as lt
+
 
 class AmazonRayStackProps:
     """Properies of the Amazon Ray onboarding stack."""
-
-    def __init__(
-        self,
-        prefix: str,
-        ami: str):
+    def __init__(self, prefix: str, ami: str):
         """Init the properties class.
 
         Parameters:
@@ -27,74 +21,66 @@ class CdkStack(core.Stack):
     The stack configures:
     1. a core Ray execution role with associated roles and policies interacting
         with other AWS services (e.g., ec2, s3, CloudWatch, CloudFormation)
-    2. a security group that allows intracluster communication and ssh inbound traffic
-    3. a launch template that contains launch parameters, e.g., AMI, IAM instance
-        profile and security group created in 2)
+    2. a security group that allows intracluster communication
+        and ssh inbound traffic
+    3. a launch template that contains launch parameters, e.g., AMI,
+        IAM instance profile and security group created in 2)
     """
-    def __init__(self, scope: core.Construct, id: str, props: AmazonRayStackProps, **kwargs) -> None:
-        super().__init__(scope, id, stack_name=f"{props.prefix}-amzn-ray-cdk", **kwargs)
+    def __init__(self, scope: core.Construct, id: str,
+                 props: AmazonRayStackProps, **kwargs) -> None:
+        super().__init__(scope,
+                         id,
+                         stack_name=f"{props.prefix}-amzn-ray-cdk",
+                         **kwargs)
         self.props = props
 
-        # Add IAM pass role for a head instance to launch worker nodes 
+        # Add IAM pass role for a head instance to launch worker nodes
         # w/ an instance profile
-        ray_iam_pass_ps = iam.PolicyStatement(
-            effect=iam.Effect.ALLOW,
-            actions=["iam:PassRole"],
-            resources=["*"]
-        )
+        ray_iam_pass_ps = iam.PolicyStatement(effect=iam.Effect.ALLOW,
+                                              actions=["iam:PassRole"],
+                                              resources=["*"])
         # Add minimum policies for an ec2 instance to launch a ray cluster
         # that creates/updates an associated CloudFormation stack.
         ray_cloudformation_ps = iam.PolicyStatement(
             effect=iam.Effect.ALLOW,
             actions=[
                 "cloudformation:UpdateStack",
-                "cloudformation:ValidateTemplate",
-                "cloudformation:ListStacks",
+                "cloudformation:ValidateTemplate", "cloudformation:ListStacks",
                 "cloudformation:DescribeStacks"
             ],
-            resources=["*"]
-        )
+            resources=["*"])
 
-        # Creates the policy
-        policy = iam.PolicyDocument(
-            statements=[
-                ray_iam_pass_ps,
-                ray_cloudformation_ps
-            ]
-        )
+        ray_exec_role_policies = iam.PolicyDocument(
+            statements=[ray_iam_pass_ps, ray_cloudformation_ps])
 
         # Ray execution Role
         ray_exec_role = iam.Role(
             self,
-            "RayExecutionRole", 
+            "RayExecutionRole",
             assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
             role_name=f"{props.prefix}RayClusterRoleCDK",
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "AmazonEC2FullAccess"
-                ),
+                    "AmazonEC2FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "AmazonS3FullAccess"
-                ),
+                    "AmazonS3FullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "CloudWatchFullAccess"
-                ),
+                    "CloudWatchFullAccess"),
                 iam.ManagedPolicy.from_aws_managed_policy_name(
-                    "AmazonSSMFullAccess"
-                )
+                    "AmazonSSMFullAccess")
             ],
-            inline_policies=[policy]
-        )
+            inline_policies=[ray_exec_role_policies])
         # Add instance profile
         # Get the underlying CfnInstanceProfile from the L2 construct
-        # CDK escape hatch docs: https://docs.aws.amazon.com/cdk/latest/guide/cfn_layer.html
+        # CDK escape hatch docs:
+        # https://docs.aws.amazon.com/cdk/latest/guide/cfn_layer.html
         ray_instance_profile = iam.CfnInstanceProfile(
             self,
             "InstanceProfile",
             roles=[ray_exec_role.role_name],
             path="/",
-            instance_profile_name=f"{props.prefix}RayClusterInstanceProfileCDK")
-        
+            instance_profile_name=f"{props.prefix}RayClusterInstanceProfileCDK"
+        )
         # Configure VPC
         vpc = ec2.Vpc.from_lookup(self, "default_vpc", is_default=True)
         ray_sg = ec2.SecurityGroup(
@@ -112,14 +98,12 @@ class CdkStack(core.Stack):
         ray_sg_connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(22))
 
         # Launch template
-        launch_template_data_property = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
-            iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(arn=ray_instance_profile.attr_arn),
+        launch_template_data_property = lt.LaunchTemplateDataProperty(
+            iam_instance_profile=lt.IamInstanceProfileProperty(
+                arn=ray_instance_profile.attr_arn),
             image_id=props.ami,
-            security_group_ids=[ray_sg.security_group_id]
-        )
-        ray_launch_tamplate = ec2.CfnLaunchTemplate(
-            self,
-            "RayClusterLaunchTemplate",
-            launch_template_name=f"{props.prefix}RayClusterLaunchTemplateCDK",
-            launch_template_data=launch_template_data_property
-        )
+            security_group_ids=[ray_sg.security_group_id])
+        lt(self,
+           "RayClusterLaunchTemplate",
+           launch_template_name=f"{props.prefix}RayClusterLaunchTemplateCDK",
+           launch_template_data=launch_template_data_property)

--- a/python/ray/autoscaler/_private/aws/cdk/ray_ec2/ray_ec2_stack.py
+++ b/python/ray/autoscaler/_private/aws/cdk/ray_ec2/ray_ec2_stack.py
@@ -1,0 +1,125 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_iam as iam,
+    core    
+)
+
+class AmazonRayStackProps:
+    """Properies of the Amazon Ray onboarding stack."""
+
+    def __init__(
+        self,
+        prefix: str,
+        ami: str):
+        """Init the properties class.
+
+        Parameters:
+            ami: AMI used in the stack
+            prefix: Prefix of resource names in the stack
+        """
+        self.prefix = prefix
+        self.ami = ami
+
+
+class CdkStack(core.Stack):
+    """Stack for setting up AWS resources required to start a Ray cluster.
+
+    The stack configures:
+    1. a core Ray execution role with associated roles and policies interacting
+        with other AWS services (e.g., ec2, s3, CloudWatch, CloudFormation)
+    2. a security group that allows intracluster communication and ssh inbound traffic
+    3. a launch template that contains launch parameters, e.g., AMI, IAM instance
+        profile and security group created in 2)
+    """
+    def __init__(self, scope: core.Construct, id: str, props: AmazonRayStackProps, **kwargs) -> None:
+        super().__init__(scope, id, stack_name=f"{props.prefix}-amzn-ray-cdk", **kwargs)
+        self.props = props
+
+        # Add IAM pass role for a head instance to launch worker nodes 
+        # w/ an instance profile
+        ray_iam_pass_ps = iam.PolicyStatement(
+            effect=iam.Effect.ALLOW,
+            actions=["iam:PassRole"],
+            resources=["*"]
+        )
+        # Add minimum policies for an ec2 instance to launch a ray cluster
+        # that creates/updates an associated CloudFormation stack.
+        ray_cloudformation_ps = iam.PolicyStatement(
+            effect=iam.Effect.ALLOW,
+            actions=[
+                "cloudformation:UpdateStack",
+                "cloudformation:ValidateTemplate",
+                "cloudformation:ListStacks",
+                "cloudformation:DescribeStacks"
+            ],
+            resources=["*"]
+        )
+
+        # Creates the policy
+        policy = iam.PolicyDocument(
+            statements=[
+                ray_iam_pass_ps,
+                ray_cloudformation_ps
+            ]
+        )
+
+        # Ray execution Role
+        ray_exec_role = iam.Role(
+            self,
+            "RayExecutionRole", 
+            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
+            role_name=f"{props.prefix}RayClusterRoleCDK",
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "AmazonEC2FullAccess"
+                ),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "AmazonS3FullAccess"
+                ),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "CloudWatchFullAccess"
+                ),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "AmazonSSMFullAccess"
+                )
+            ],
+            inline_policies=[policy]
+        )
+        # Add instance profile
+        # Get the underlying CfnInstanceProfile from the L2 construct
+        # CDK escape hatch docs: https://docs.aws.amazon.com/cdk/latest/guide/cfn_layer.html
+        ray_instance_profile = iam.CfnInstanceProfile(
+            self,
+            "InstanceProfile",
+            roles=[ray_exec_role.role_name],
+            path="/",
+            instance_profile_name=f"{props.prefix}RayClusterInstanceProfileCDK")
+        
+        # Configure VPC
+        vpc = ec2.Vpc.from_lookup(self, "default_vpc", is_default=True)
+        ray_sg = ec2.SecurityGroup(
+            self,
+            "RayClusterSecurityGroup",
+            vpc=vpc,
+            description="Ray cluster security group.",
+            security_group_name=f"{props.prefix}RayClusterSecurityGroupCDK",
+            allow_all_outbound=True,
+        )
+        ray_sg_connections = ec2.Connections(security_groups=[ray_sg])
+        # Enable ray intracluster communication
+        ray_sg_connections.allow_from(ray_sg, ec2.Port.tcp_range(0, 65535))
+        # Enable ssh to the instance
+        ray_sg_connections.allow_from(ec2.Peer.any_ipv4(), ec2.Port.tcp(22))
+
+        # Launch template
+        launch_template_data_property = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
+            iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(arn=ray_instance_profile.attr_arn),
+            image_id=props.ami,
+            security_group_ids=[ray_sg.security_group_id]
+        )
+        ray_launch_tamplate = ec2.CfnLaunchTemplate(
+            self,
+            "RayClusterLaunchTemplate",
+            launch_template_name=f"{props.prefix}RayClusterLaunchTemplateCDK",
+            launch_template_data=launch_template_data_property
+        )

--- a/python/ray/autoscaler/_private/aws/cdk/requirements.txt
+++ b/python/ray/autoscaler/_private/aws/cdk/requirements.txt
@@ -1,0 +1,4 @@
+aws-cdk.core
+
+aws-cdk.aws-ec2
+aws-cdk.aws-iam


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/amzn/amazon-ray/blob/master/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a CDK Python project to automate the process of configuring AWS resources needed for setting up a Ray cluster. It defines cloud infrastructure required to launch the cluster as code, and delegates to AWS CloudFormation for 
infrastructure provisioning.
This PR paves the way for further providing deterministic, idempotent, flexible, and maintainable AWS account bootstrapping for Ray clusters (i.e. everything but node provisioning/deprovisioning). 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I'm working against the latest source on the **experimental** branch.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] `./deploy-cdk.sh -s demo` to set up the CloudFormation stack; `ray up config.py` to start the cluster

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
