### PR TITLE
[autoscaler] Always restart cloudwatch agent to support existing installations.

### DIFF
--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
@@ -10,11 +10,11 @@
    "logs":{
       "metrics_collected": {
         "prometheus": {
-          "log_group_name": "{cluster_name}-Prometheus",
-          "prometheus_config_path": "/opt/prometheus-2.25.0.linux-amd64/prometheus.yml",
+          "log_group_name": "{cluster_name}-ray-prometheus",
+          "prometheus_config_path": "/opt/prometheus/prometheus.yml",
           "emf_processor": {
             "metric_declaration_dedup": true,
-            "metric_namespace": "{cluster_name}-Prometheus",
+            "metric_namespace": "{cluster_name}-ray-prometheus",
             "metric_unit":{
               "python_gc_collections_total": "Count",
               "python_gc_objects": "Count",

--- a/python/ray/autoscaler/aws/cloudwatch/prometheus_ray_up.sh
+++ b/python/ray/autoscaler/aws/cloudwatch/prometheus_ray_up.sh
@@ -21,19 +21,19 @@ if [ $? -eq 0 ]; then
   # TODO remove the version number hardcoding from this script
   # download the latest prometheus
   ray exec "$AUTOSCALER_CONFIG_FILE" "sudo wget https://github.com/prometheus/prometheus/releases/download/v2.25.0/prometheus-2.25.0.linux-amd64.tar.gz -P /opt"
-  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt && sudo tar xvfz prometheus-2.25.0.linux-amd64.tar.gz"
+  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt && sudo tar xvfz prometheus-2.25.0.linux-amd64.tar.gz && sudo mv prometheus-2.25.0.linux-amd64 prometheus && sudo rm prometheus-2.25.0.linux-amd64.tar.gz"
   echo "Successfully installed prometheus on head node"
 
   # replace the default prometheus server configuration with ray services discovery supported configuration
-  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo cp --remove-destination /tmp/prometheus.yml /opt/prometheus-2.25.0.linux-amd64"
+  ray exec "$AUTOSCALER_CONFIG_FILE" "sudo cp --remove-destination /tmp/prometheus.yml /opt/prometheus"
   echo "Successfully configured prometheus on head node"
 
   # start the prometheus server
-  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt/prometheus-2.25.0.linux-amd64 && sudo ./prometheus --config.file=prometheus.yml --web.enable-lifecycle --log.level=info &"
+  ray exec "$AUTOSCALER_CONFIG_FILE" "cd /opt/prometheus && sudo ./prometheus --config.file=prometheus.yml --web.enable-lifecycle --log.level=info &"
   echo "Successfully started prometheus on head node"
 
   # restart the cloudwatch agent with prometheus integrated
-  echo "Restarting cloudwatch agent...this may take a few minutes."
+  echo "Restarting cloudwatch agent. This may take a few minutes..."
   ray exec "$AUTOSCALER_CONFIG_FILE" "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -m ec2 -a stop"
   ray exec "$AUTOSCALER_CONFIG_FILE" "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c ssm:ray_cloudwatch_agent_config_$CLUSTER_NAME"
 

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -199,12 +199,16 @@ def test_cloudwatch_agent_setup(ec2_client_stub, ssm_client_stub):
     # expect to wait for the command to complete successfully on every node
     stubs.list_command_invocations_success(ssm_client_stub, node_ids, cmd_id)
 
+    cw_ssm_param_name = helpers.get_ssm_param_name(
+        cloudwatch_helper.cluster_name, "agent")
     # given that all CloudWatch Agent start preconditions are satisfied...
-    # expect to send an SSM command to start CloudWatch Agent on all nodes
-    parameter_name = helpers.get_ssm_param_name(cloudwatch_helper.cluster_name,
-                                                "agent")
+    # expect to send an SSM command to restart CloudWatch Agent on all nodes
+    cmd_id = stubs.send_command_stop_cwa(ssm_client_stub, node_ids)
+    # given a SSM command to stop CloudWatch Agent sent to all nodes...
+    # expect to wait for the command to complete successfully on every node
+    stubs.list_command_invocations_success(ssm_client_stub, node_ids, cmd_id)
     cmd_id = stubs.send_command_start_cwa(ssm_client_stub, node_ids,
-                                          parameter_name)
+                                          cw_ssm_param_name)
     # given a SSM command to start CloudWatch Agent sent to all nodes...
     # expect to wait for the command to complete successfully on every node
     stubs.list_command_invocations_success(ssm_client_stub, node_ids, cmd_id)
@@ -331,7 +335,7 @@ def test_cloudwatch_agent_update_without_cwa_preinstalled(
 
     # given a directive to update a cluster CloudWatch Agent Config without
     # preinstalled agent...
-    # expect the call to retrive the CloudWatch Agent Config gets an exception
+    # expect the call to retrieve the CloudWatch Agent Config gets an exception
     cw_ssm_param_name = helpers.get_ssm_param_name(
         cloudwatch_helper.cluster_name, "agent")
     stubs.get_param_ssm_exception(ssm_client_stub, cw_ssm_param_name)
@@ -357,7 +361,11 @@ def test_cloudwatch_agent_update_without_cwa_preinstalled(
     stubs.list_command_invocations_success(ssm_client_stub, node_ids, cmd_id)
 
     # given that all CloudWatch Agent start preconditions are satisfied...
-    # expect to send an SSM command to start CloudWatch Agent on all nodes
+    # expect to send an SSM command to restart CloudWatch Agent on all nodes
+    cmd_id = stubs.send_command_stop_cwa(ssm_client_stub, node_ids)
+    # given a SSM command to stop CloudWatch Agent sent to all nodes...
+    # expect to wait for the command to fail on every node
+    stubs.list_command_invocations_failed(ssm_client_stub, node_ids, cmd_id)
     cmd_id = stubs.send_command_start_cwa(ssm_client_stub, node_ids,
                                           cw_ssm_param_name)
     # given a SSM command to start CloudWatch Agent sent to all nodes...

--- a/python/ray/tests/aws/utils/stubs.py
+++ b/python/ray/tests/aws/utils/stubs.py
@@ -196,7 +196,7 @@ def send_command_cwa_install(ssm_client_stub, node_ids):
     return command_id
 
 
-def list_command_invocations_success(ssm_client_stub, node_ids, cmd_id):
+def list_command_invocations_status(ssm_client_stub, node_ids, cmd_id, status):
     for node_id in node_ids:
         ssm_client_stub.add_response(
             "list_command_invocations",
@@ -205,8 +205,18 @@ def list_command_invocations_success(ssm_client_stub, node_ids, cmd_id):
                 "InstanceId": node_id
             },
             service_response={"CommandInvocations": [{
-                "Status": "Success"
+                "Status": status
             }]})
+
+
+def list_command_invocations_failed(ssm_client_stub, node_ids, cmd_id):
+    status = "Failed"
+    list_command_invocations_status(ssm_client_stub, node_ids, cmd_id, status)
+
+
+def list_command_invocations_success(ssm_client_stub, node_ids, cmd_id):
+    status = "Success"
+    list_command_invocations_status(ssm_client_stub, node_ids, cmd_id, status)
 
 
 def put_parameter_cloudwatch_config(ssm_client_stub, cluster_name,
@@ -282,7 +292,6 @@ def send_command_stop_cwa(ssm_client_stub, node_ids):
             "Parameters": {
                 "action": ["stop"],
                 "mode": ["ec2"],
-                "optionalConfigurationSource": ["ssm"]
             }
         },
         service_response={"Command": {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/amzn/amazon-ray/blob/master/CONTRIBUTING.md before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change resolves failures that otherwise occur when attempting to start the cloudwatch agent on a Ray cluster whenever the cloudwatch unified agent is already installed and running on 1 or more nodes but wasn't configured via our CloudwatchHelper class during `ray up`. For example, this failure is encountered when launching a new cluster from an existing Amazon Ray AMI in a new AWS account with the following autoscaler config section specified:
```yaml
provider:
    type: aws
    region: us-east-1
    availability_zone: us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f
    cloudwatch:
      agent:
        config: "./python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json"
```

To resolve this error, this change ensures that we never just try to start the cloudwatch agent, but first ensure that any existing cloudwatch agent instances are stopped (ignoring any failures that occur if it is not installed) before issuing a subsequent SSM command to start the cloudwatch agent on all nodes in the cluster.

Also some minor refactoring of prometheus/cloudwatch integration:
1. Example metric namespace renamed from `{cluster-name}-Prometheus` to `{cluster-name}-ray-prometheus`.
2. Always install any prometheus version in `/opt/prometheus` instead of `/opt/prometheus-{version}-{platform}` to reduce changes across files referencing the prometheus install directory over time.
3. Remove the prometheus installation package after installation completes.

## Checks

- [X] I'm working against the latest source on the **experimental** branch.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
