### PR TITLE
Add AWS SNS event callback during cluster setup (Ray 1.11.0)

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -11,7 +11,6 @@ import logging
 
 import boto3
 import botocore
-from botocore.exceptions import ClientError
 from ray.autoscaler._private.aws.events import AwsEventManager
 from ray.autoscaler._private.util import check_legacy_fields
 from ray.autoscaler.tags import NODE_TYPE_LEGACY_HEAD, NODE_TYPE_LEGACY_WORKER

--- a/python/ray/autoscaler/_private/aws/events.py
+++ b/python/ray/autoscaler/_private/aws/events.py
@@ -75,7 +75,8 @@ class AwsEventManager:
                 event.name, sns_topic_arn))
         except ClientError as exc:
             cli_logger.abort(
-                "Failed to execute callback for create cluster events: {}", exc)
+                "{} Error caught when publishing {} create cluster events to SNS",
+                exc.response["Error"], event.name)
 
     def _lambda_callback(self):
         raise NotImplementedError("AWS Lambda callback is currently not supported")

--- a/python/ray/autoscaler/_private/aws/events.py
+++ b/python/ray/autoscaler/_private/aws/events.py
@@ -1,0 +1,88 @@
+import copy
+import json
+import logging
+import time
+from typing import Dict, Any
+
+from botocore.exceptions import ClientError
+
+from ray.autoscaler._private.aws.sns.snsu import SnsHelper
+from ray.autoscaler._private.cli_logger import cli_logger
+from ray.autoscaler._private.event_system import CreateClusterEvent, global_event_system
+from ray.autoscaler._private.updater import NodeContext
+
+logger = logging.getLogger(__name__)
+
+
+class AwsEventManager:
+    def __init__(self, events_config: Dict[str, Any]):
+        self.uri = notification_uri = events_config["notification_uri"]
+        assert notification_uri is not None, f"`notification_uri` is a required field in `events`"
+        assert "arn:aws" in notification_uri, f"Invalid ARN specified: {notification_uri}"
+        self.parameters = events_config.get("parameters", {})
+
+    def add_callback(self, event: CreateClusterEvent):
+        """Adds a callback handler based on the ARN that is supplied in `events.notification_uri`.
+        Currently, only SNS topics are supported.
+
+        Args:
+            event: The cluster event to invoke the callback handler for
+        """
+        if self.uri.startswith("arn:aws:sns"):
+            global_event_system.add_callback_handler(event,
+                                                     self._sns_callback,
+                                                     SnsHelper(self._get_region()),
+                                                     **self.parameters)
+        elif self.uri.startswith("arn:aws:lambda"):
+            global_event_system.add_callback_handler(event, self._lambda_callback)
+        elif self.uri.startswith("arn:aws:logs"):
+            global_event_system.add_callback_handler(event, self._cloudwatch_callback)
+        elif self.uri.startswith("arn:aws:apigateway"):
+            global_event_system.add_callback_handler(event, self._api_gateway_callback)
+
+    def _get_region(self):
+        return self.uri.split(":")[3]
+
+    def _sns_callback(self, sns_client: SnsHelper, event_data: Dict[str, Any], **kwargs):
+        """SNS callback for sending Ray cluster event data to an SNS topic.
+
+        Args:
+            sns_client: Amazon SNS client for publishing to an SNS topic
+            event_data: Ray cluster setup event data. This contains the event name, enum ID, and
+                may also contain additional metadata (i.e. the initialization or setup command used
+                during this setup step)
+            **kwargs: Keyword arguments that were injected into `_EventSystem.add_callback_handler`
+        """
+        try:
+            # create a copy of the event data to modify
+            event_dict = copy.deepcopy(event_data)
+            event: CreateClusterEvent = event_dict.pop("event_name")
+            node_context: NodeContext = event_dict.get("node_context", {})
+            sns_topic_arn, params = self.uri, kwargs
+            message = {
+                **params,
+                "setupEventMetadata": event_dict,
+                "stateSequence": event.value - 1,  # zero-index sequencing
+                "timestamp": round(time.time() * 1000)
+            }
+
+            if node_context:
+                message["rayNodeId"] = node_context["node_id"]
+                message["rayNodeType"] = "HEAD" if node_context["is_head_node"] else "WORKER"
+
+            sns_client.publish(sns_topic_arn, json.dumps(message))
+            logger.info("Published SNS event {} to {}".format(
+                event.name, sns_topic_arn))
+        except ClientError as exc:
+            cli_logger.abort(
+                "Failed to execute callback for create cluster events: {}", exc)
+
+    def _lambda_callback(self):
+        raise NotImplementedError("AWS Lambda callback is currently not supported")
+
+    def _cloudwatch_callback(self):
+        raise NotImplementedError("AWS Cloudwatch callback is currently not supported")
+
+    def _api_gateway_callback(self):
+        raise NotImplementedError("AWS API Gateway callback is currently not supported")
+

--- a/python/ray/autoscaler/_private/aws/sns/snsu.py
+++ b/python/ray/autoscaler/_private/aws/sns/snsu.py
@@ -1,0 +1,21 @@
+from ray.autoscaler._private.aws.utils import client_cache
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class SnsHelper:
+    def __init__(self, region: str, **kwargs):
+        self.sns = client_cache("sns", region, **kwargs)
+
+    def subscribe(self,
+                  topic_arn: str) -> str:
+        response = self.sns.subscribe(TopicArn=topic_arn, Protocol='https')
+        return response['SubscriptionArn']
+
+    def publish(self,
+                topic_arn: str,
+                message: str) -> Dict[str, Any]:
+        response = self.sns.publish(TopicArn=topic_arn, Message=message)
+        return response

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -38,7 +38,7 @@ from ray.autoscaler.tags import (
     NODE_KIND_WORKER, NODE_KIND_HEAD, TAG_RAY_USER_NODE_TYPE,
     STATUS_UNINITIALIZED, STATUS_UP_TO_DATE, TAG_RAY_NODE_STATUS)
 from ray.autoscaler._private.cli_logger import cli_logger, cf
-from ray.autoscaler._private.updater import NodeUpdaterThread
+from ray.autoscaler._private.updater import NodeUpdaterThread, NodeContext
 from ray.autoscaler._private.command_runner import set_using_login_shells, \
     set_rsync_silent
 from ray.autoscaler._private.event_system import (CreateClusterEvent,
@@ -649,7 +649,8 @@ def get_or_create_head_node(config: Dict[str, Any],
                     time.sleep(POLL_INTERVAL)
             cli_logger.newline()
 
-    global_event_system.execute_callback(CreateClusterEvent.head_node_acquired)
+    global_event_system.execute_callback(CreateClusterEvent.head_node_acquired,
+                                         {"node_context": NodeContext(head_node, True)})
 
     with cli_logger.group(
             "Setting up head node",
@@ -725,9 +726,7 @@ def get_or_create_head_node(config: Dict[str, Any],
             sys.exit(1)
 
     global_event_system.execute_callback(
-        CreateClusterEvent.cluster_booting_completed, {
-            "head_node_id": head_node,
-        })
+        CreateClusterEvent.cluster_booting_completed, {"node_context": NodeContext(head_node, True)})
 
     monitor_str = "tail -n 100 -f /tmp/ray/session_latest/logs/monitor*"
     if override_cluster_name:

--- a/python/ray/autoscaler/_private/event_system.py
+++ b/python/ray/autoscaler/_private/event_system.py
@@ -1,3 +1,4 @@
+import functools
 from enum import Enum, auto
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -54,6 +55,8 @@ class _EventSystem:
             event: str,
             callback: Union[Callable[[Dict], None], List[Callable[[Dict],
                                                                   None]]],
+            *args,
+            **kwargs,
     ):
         """Stores callback handler for event.
 
@@ -63,11 +66,14 @@ class _EventSystem:
                 registered against.
             callback (Callable[[Dict], None]): Callable object that is invoked
                 when specified event occurs.
+            *args: Variable length arguments to be injected into callbacks.
+            **kwargs: Keyword arguments to be injected into callbacks.
         """
         if event not in CreateClusterEvent.__members__.values():
             cli_logger.warning(f"{event} is not currently tracked, and this"
                                " callback will not be invoked.")
 
+        callback = functools.partial(callback, *args, **kwargs)
         self.callback_map.setdefault(
             event,
             []).extend([callback] if type(callback) is not list else callback)

--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -291,6 +291,7 @@ class NodeUpdater:
                         time.sleep(READY_CHECK_INTERVAL)
 
     def do_update(self):
+        node_context = NodeContext(self.node_id, self.is_head_node)
         self.provider.set_node_tags(
             self.node_id, {TAG_RAY_NODE_STATUS: STATUS_WAITING_FOR_SSH})
         cli_logger.labeled_value("New status", STATUS_WAITING_FOR_SSH)
@@ -298,7 +299,7 @@ class NodeUpdater:
         deadline = time.time() + AUTOSCALER_NODE_START_WAIT_S
         self.wait_ready(deadline)
         global_event_system.execute_callback(
-            CreateClusterEvent.ssh_control_acquired)
+            CreateClusterEvent.ssh_control_acquired, {"node_context": node_context})
 
         node_tags = self.provider.node_tags(self.node_id)
         logger.debug("Node tags: {}".format(str(node_tags)))
@@ -363,14 +364,16 @@ class NodeUpdater:
                             "Running initialization commands",
                             _numbered=("[]", 4, NUM_SETUP_STEPS)):
                         global_event_system.execute_callback(
-                            CreateClusterEvent.run_initialization_cmd)
+                            CreateClusterEvent.run_initialization_cmd,
+                            {"node_context": node_context})
                         with LogTimer(
                                 self.log_prefix + "Initialization commands",
                                 show_status=True):
                             for cmd in self.initialization_commands:
                                 global_event_system.execute_callback(
                                     CreateClusterEvent.run_initialization_cmd,
-                                    {"command": cmd})
+                                    {"command": cmd,
+                                     "node_context": node_context})
                                 try:
                                     # Overriding the existing SSHOptions class
                                     # with a new SSHOptions class that uses
@@ -409,7 +412,8 @@ class NodeUpdater:
                             # todo: fix command numbering
                             _numbered=("[]", 6, NUM_SETUP_STEPS)):
                         global_event_system.execute_callback(
-                            CreateClusterEvent.run_setup_cmd)
+                            CreateClusterEvent.run_setup_cmd,
+                            {"node_context": node_context})
                         with LogTimer(
                                 self.log_prefix + "Setup commands",
                                 show_status=True):
@@ -418,7 +422,8 @@ class NodeUpdater:
                             for i, cmd in enumerate(self.setup_commands):
                                 global_event_system.execute_callback(
                                     CreateClusterEvent.run_setup_cmd,
-                                    {"command": cmd})
+                                    {"command": cmd,
+                                     "node_context": node_context})
                                 if cli_logger.verbosity == 0 and len(cmd) > 30:
                                     cmd_to_print = cf.bold(cmd[:30]) + "..."
                                 else:
@@ -449,7 +454,8 @@ class NodeUpdater:
                 "Starting the Ray runtime", _numbered=("[]", 7,
                                                        NUM_SETUP_STEPS)):
             global_event_system.execute_callback(
-                CreateClusterEvent.start_ray_runtime)
+                CreateClusterEvent.start_ray_runtime,
+                {"node_context": node_context})
             with LogTimer(
                     self.log_prefix + "Ray start commands", show_status=True):
                 for cmd in self.ray_start_commands:
@@ -481,7 +487,8 @@ class NodeUpdater:
 
                         raise click.ClickException("Start command failed.")
             global_event_system.execute_callback(
-                CreateClusterEvent.start_ray_runtime_completed)
+                CreateClusterEvent.start_ray_runtime_completed,
+                {"node_context": node_context})
 
     def rsync_up(self, source, target, docker_mount_if_possible=False):
         options = {}
@@ -507,3 +514,8 @@ class NodeUpdaterThread(NodeUpdater, Thread):
         Thread.__init__(self)
         NodeUpdater.__init__(self, *args, **kwargs)
         self.exitcode = -1
+
+
+class NodeContext(dict):
+    def __init__(self, node_id: str, is_head_node: bool):
+        dict.__init__(self, node_id=node_id, is_head_node=is_head_node)

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -59,6 +59,21 @@
             "type": "number",
             "minimum": 0
         },
+        "events": {
+          "type": "object",
+          "description": "Event callback configuration",
+          "additionalProperties": true,
+          "properties": {
+            "notification_uri": {
+              "type": "string",
+              "description": "cloud provider resource identifier to send events to"
+            },
+            "parameters": {
+              "type": "object",
+              "description": "additional metadata to include into each event notification"
+            }
+          }
+        },
         "provider": {
             "type": "object",
             "description": "Cloud-provider specific configuration.",


### PR DESCRIPTION
<!-- Please give a short summary of the change and the problem this solves. -->
This PR adds a SNS event callback for each Ray cluster setup event. Tested with `ray up`, `ray exec`.

To configure, the `events` field must be added to the cluster config YAML

`events` takes the following arguments:
- `notification_uri`: Cloud specific resource identifier for dispatching events to. This may vary based on which cloud provider you use (e.g. GCP, AWS, Azure). For this implementation, SNS topic [ARNs](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) are taken as valid input.
- `parameters`: Arbitrary key-value parameters that you want to include into the payload of each callback. This might be useful, if for example, you need to pass in additional metadata for a particular Ray job, such as the job ID.


This PR is rebased off of the `experimental` branch with 1.11.0. Old PR: https://github.com/amzn/amazon-ray/pull/96

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I'm working against the latest source on the **experimental** branch.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.